### PR TITLE
chore: set the sources URLs to point to github.com

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,9 @@ test:
     - pytest
 
 about:
-  home: https://gitlab.idiap.ch/software/clapper
+  home: https://github.com/idiap/clapper
   doc_url: https://clapper.readthedocs.io
-  dev_url: https://gitlab.idiap.ch/software/clapper
+  dev_url: https://github.com/idiap/clapper
   summary: Configuration Support for Python Packages and CLIs
   license: BSD-3-Clause
   license_file: LICENSES/BSD-3-Clause.txt
@@ -51,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - anjos
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,4 +51,3 @@ about:
 extra:
   recipe-maintainers:
     - anjos
-


### PR DESCRIPTION
Change the package recipe to create metadata that point to github.com instead of gitlab.idiap.ch for the sources.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
